### PR TITLE
Fix vagrant up failure due to lack of plugin vagrant-env (#27).

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,8 @@ Vagrant.require_version ">= 2.2.9"
 
 Vagrant.configure("2") do |config|
 
+  config.vagrant.plugins = {"vagrant-env" => {"version" => "0.0.3"}}
+
   config.vm.define "laprimaire_2022" do |host|
     host.vm.box = "ubuntu/focal64"
     host.vm.hostname = "2022.laprimaire.org.test"


### PR DESCRIPTION
I added a line to the Vagrantfile so that the plugin "vagrant-env" is automatically installed if it is not already.

I also specified the plugin version to avoid potential future problems, let me know it you think this is a bad idea.