### PR TITLE
Add the ansible_managed comment on all templates.

### DIFF
--- a/provisioning/roles/laprimaire.analytics/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.analytics/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 version: "3"
 
 services:

--- a/provisioning/roles/laprimaire.blog/templates/analytics.js.j2
+++ b/provisioning/roles/laprimaire.blog/templates/analytics.js.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment('c') }}
 var _paq = window._paq = window._paq || [];
 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 _paq.push(['trackPageView']);

--- a/provisioning/roles/laprimaire.blog/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.blog/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 version: '3.3'
 
 services:

--- a/provisioning/roles/laprimaire.forum/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.forum/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 version: '3.3'
 
 services:

--- a/provisioning/roles/laprimaire.logs/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.logs/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 version: '3'
 
 services:

--- a/provisioning/roles/laprimaire.monitoring/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.monitoring/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 ---
 
 version: '3.3'
@@ -60,7 +61,7 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command: 
+    command:
       - '--path.procfs=/host/proc'
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'

--- a/provisioning/roles/laprimaire.reverse-proxy/templates/docker-compose.yml.j2
+++ b/provisioning/roles/laprimaire.reverse-proxy/templates/docker-compose.yml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 version: "3.3"
 
 services:

--- a/provisioning/roles/laprimaire.reverse-proxy/templates/vouch.conf.j2
+++ b/provisioning/roles/laprimaire.reverse-proxy/templates/vouch.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 proxy_set_header Host $http_host;
 
 # send all requests to the `/validate` endpoint for authorization

--- a/provisioning/roles/laprimaire.reverse-proxy/templates/vouch_location.conf.j2
+++ b/provisioning/roles/laprimaire.reverse-proxy/templates/vouch_location.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # forward authorized requests to your service protectedapp.yourdomain.com
 # proxy_pass http://127.0.0.1:8080;
 # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810


### PR DESCRIPTION
Solves https://github.com/democratech/2022/issues/45.

To check the generated files, I've provisioned the project using this command of the README:
```bash
ANSIBLE_EXTRA_ARGS='-e vouch_enabled=true' vagrant provision
```

- **Files generated before the fix:**
```bash
vagrant@2022:~$ head /srv/logs/docker-compose.yml /srv/matomo/docker-compose.yml /srv/monitoring/docker-compose.yml /srv/discourse/docker-compose.yml /srv/ghost/docker-compose.yml /data/ghost/content/themes/lyra/assets/js/analytics.js /data/grafana/config/grafana.ini /data/prometheus/config/rules/ansible_managed.rules /data/prometheus/config/prometheus.yml /srv/nginx/docker-compose.yml
==> /srv/logs/docker-compose.yml <==
version: '3'

services:
  elasticsearch:
    image: elasticsearch:7.6.2
    restart: unless-stopped
    environment:
      - "discovery.type=single-node"
      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
    ulimits:

==> /srv/matomo/docker-compose.yml <==
version: "3"

services:
  mariadb:
    image: "docker.io/bitnami/mariadb:10.3-debian-10"
    restart: unless-stopped
    environment:
      MARIADB_ROOT_PASSWORD: "root"
      MARIADB_USER: "matomo"
      MARIADB_PASSWORD: "admin_42"

==> /srv/monitoring/docker-compose.yml <==
---

version: '3.3'

services:
  grafana:
    image: grafana/grafana:7.4.5
    restart: unless-stopped
    networks:
      - grafana

==> /srv/discourse/docker-compose.yml <==
version: '3.3'

services:
  postgresql:
    image: 'docker.io/bitnami/postgresql:12'
    restart: unless-stopped
    environment:
      POSTGRESQL_PASSWORD: "postgres"
    volumes:
      - '/data/discourse/postgresql:/bitnami/postgresql'

==> /srv/ghost/docker-compose.yml <==
version: '3.3'

services:
  ghost:
    image: ghost:4-alpine
    restart: unless-stopped
    environment:
      # see https://docs.ghost.org/docs/config#section-running-ghost-with-config-env-variables
      database__client: "mysql"
      database__connection__host: "db"

==> /data/ghost/content/themes/lyra/assets/js/analytics.js <==
var _paq = window._paq = window._paq || [];
/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
_paq.push(['trackPageView']);
_paq.push(['enableLinkTracking']);
(function() {
    var u="//analytics.infra.laprimaire.org.test/";
    _paq.push(['setTrackerUrl', u+'matomo.php']);
    _paq.push(['setSiteId', '1']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);

==> /data/grafana/config/grafana.ini <==
#
# Ansible managed
#
# More informations:
# http://docs.grafana.org/installation/configuration
# https://github.com/grafana/grafana/blob/master/conf/sample.ini

app_mode = production
instance_name = 2022


==> /data/prometheus/config/rules/ansible_managed.rules <==
#
# Ansible managed
#

groups:
- name: ansible managed alert rules
  rules:
  - alert: Watchdog
    annotations:
      description: 'This is an alert meant to ensure that the entire alerting pipeline

==> /data/prometheus/config/prometheus.yml <==
#
# Ansible managed
#
# http://prometheus.io/docs/operating/configuration/

global:
  evaluation_interval: 15s
  scrape_interval: 15s
  scrape_timeout: 10s


==> /srv/nginx/docker-compose.yml <==
version: "3.3"

services:
  nginx-proxy:
    image: jwilder/nginx-proxy:0.8.0
    container_name: nginx-proxy
    restart: unless-stopped
    ports:
      - 80:80
      - 443:443
```

- **Files generated after the fix:**

```bash
vagrant@2022:~$ head -n5 /srv/logs/docker-compose.yml /srv/matomo/docker-compose.yml /srv/monitoring/docker-compose.yml /srv/discourse/docker-compose.yml /srv/ghost/docker-compose.yml /data/ghost/content/themes/lyra/assets/js/analytics.js /data/grafana/config/grafana.ini /data/prometheus/config/rules/ansible_managed.rules /data/prometheus/config/prometheus.yml /srv/nginx/docker-compose.yml /srv/nginx/vhost.d/analytics.infra.laprimaire.org.test /srv/nginx/vhost.d/analytics.infra.laprimaire.org.test_location 
==> /srv/logs/docker-compose.yml <==
#
# Ansible managed
#
version: '3'


==> /srv/matomo/docker-compose.yml <==
#
# Ansible managed
#
version: "3"


==> /srv/monitoring/docker-compose.yml <==
#
# Ansible managed
#
---


==> /srv/discourse/docker-compose.yml <==
#
# Ansible managed
#
version: '3.3'


==> /srv/ghost/docker-compose.yml <==
#
# Ansible managed
#
version: '3.3'


==> /data/ghost/content/themes/lyra/assets/js/analytics.js <==
//
// Ansible managed
//
var _paq = window._paq = window._paq || [];
/* tracker methods like "setCustomDimension" should be called before "trackPageView" */

==> /data/grafana/config/grafana.ini <==
#
# Ansible managed
#
# More informations:
# http://docs.grafana.org/installation/configuration

==> /data/prometheus/config/rules/ansible_managed.rules <==
#
# Ansible managed
#

groups:

==> /data/prometheus/config/prometheus.yml <==
#
# Ansible managed
#
# http://prometheus.io/docs/operating/configuration/


==> /srv/nginx/docker-compose.yml <==
#
# Ansible managed
#
version: "3.3"


==> /srv/nginx/vhost.d/analytics.infra.laprimaire.org.test <==
#
# Ansible managed
#
proxy_set_header Host $http_host;


==> /srv/nginx/vhost.d/analytics.infra.laprimaire.org.test_location <==
#
# Ansible managed
#
# forward authorized requests to your service protectedapp.yourdomain.com
# proxy_pass http://127.0.0.1:8080;
```
