### PR TITLE
Fix ansible-lint errors (#6).

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,7 @@
+---
+exclude_paths:
+  - provisioning/roles/geerlingguy.docker/
+  - provisioning/roles/geerlingguy.pip/
+
+skip_list:
+  - '204' # Ignore error [204] Lines should be no longer than 160 chars

--- a/provisioning/roles/laprimaire.blog/handlers/main.yml
+++ b/provisioning/roles/laprimaire.blog/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: restart ghost
-  shell: docker-compose restart
+  command: docker-compose restart
   args:
     chdir: /srv/ghost

--- a/provisioning/roles/laprimaire.logs/handlers/main.yml
+++ b/provisioning/roles/laprimaire.logs/handlers/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: restart EFK
-  shell: docker-compose restart
+  command: docker-compose restart
   args:
     chdir: /srv/logs
 
 - name: restart fluent-bit
-  shell: docker-compose restart fluent-bit
+  command: docker-compose restart fluent-bit
   args:
     chdir: /srv/logs

--- a/provisioning/roles/laprimaire.monitoring/handlers/main.yml
+++ b/provisioning/roles/laprimaire.monitoring/handlers/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: restart monitoring
-  shell: docker-compose restart
+  command: docker-compose restart
   args:
     chdir: /srv/monitoring
 
 - name: restart prometheus
-  shell: docker-compose restart prometheus
+  command: docker-compose restart prometheus
   args:
     chdir: /srv/monitoring
 
 - name: restart grafana
-  shell: docker-compose restart grafana
+  command: docker-compose restart grafana
   args:
     chdir: /srv/monitoring

--- a/provisioning/roles/laprimaire.reverse-proxy/handlers/main.yml
+++ b/provisioning/roles/laprimaire.reverse-proxy/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: restart nginx-proxy
-  shell: docker-compose restart nginx-proxy
+  command: docker-compose restart nginx-proxy
   args:
     chdir: /srv/nginx

--- a/provisioning/roles/laprimaire.reverse-proxy/tasks/main.yml
+++ b/provisioning/roles/laprimaire.reverse-proxy/tasks/main.yml
@@ -24,12 +24,14 @@
 
 - name: enable vouch vhosts
   block:
-    - template:
+    - name: create vouch.conf
+      template:
         src: vouch.conf.j2
         dest: "/srv/nginx/vhost.d/{{ hostvars[item]['ansible_host'] }}"
       loop: "{{ groups['infra'] }}"
       notify: restart nginx-proxy
-    - template:
+    - name: create vouch_location.conf
+      template:
         src: vouch_location.conf.j2
         dest: "/srv/nginx/vhost.d/{{ hostvars[item]['ansible_host'] }}_location"
       loop: "{{ groups['infra'] }}"
@@ -38,12 +40,14 @@
 
 - name: disable vouch vhosts
   block:
-    - file:
+    - name: delete vouch.conf
+      file:
         path: "/srv/nginx/vhost.d/{{ hostvars[item]['ansible_host'] }}"
         state: absent
       loop: "{{ groups['infra'] }}"
       notify: restart nginx-proxy
-    - file:
+    - name: delete vouch_location.conf
+      file:
         path: "/srv/nginx/vhost.d/{{ hostvars[item]['ansible_host'] }}_location"
         state: absent
       loop: "{{ groups['infra'] }}"

--- a/provisioning/roles/laprimaire.ssl-certs/tasks/main.yml
+++ b/provisioning/roles/laprimaire.ssl-certs/tasks/main.yml
@@ -16,6 +16,6 @@
       -subj "/C=FR/ST=IdF/L=Paris/O=IT/CN={{ ssl_cert_fqdn }}" \
       -days 3650 \
       -keyout /srv/nginx/certs/{{ ssl_cert_fqdn }}.key \
-      -out /srv/nginx/certs/{{ ssl_cert_fqdn }}.crt 
+      -out /srv/nginx/certs/{{ ssl_cert_fqdn }}.crt
   args:
     creates: "/srv/nginx/certs/{{ ssl_cert_fqdn }}.crt"


### PR DESCRIPTION
This PR:
- Adds a `.ansible-lint` file at the root of the repo to:
    - Ignore the files in `provisioning/roles/geerlingguy.docker` and `provisioning/roles/geerlingguy.pip`.
    - Ignore the linting error `[204] Lines should be no longer than 160 chars`.
- Fixes linting errors:
    - Fixes use of `shell` instead of `command`.
    - Fixes missing block task name.
    - Fixes extra space at end of line.