### PR TITLE
Add ansible-lint GitHub Action (#6).

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,4 +4,6 @@ exclude_paths:
   - provisioning/roles/geerlingguy.pip/
 
 skip_list:
-  - '204' # Ignore error [204] Lines should be no longer than 160 chars
+  - '106' # Ignore error [106] Role name does not match ^[a-z][a-z0-9_]+$ pattern.
+  - '204' # Ignore error [204] Lines should be no longer than 160 chars.
+  - '208' # Ignore error [208] File permissions unset or incorrect.

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,51 @@
+name: Ansible Lint
+
+on: [push, pull_request]
+
+jobs:
+  ansible-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint-action@c37fb7b4bda2c8cb18f4942716bae9f11b0dc9bc
+      with:
+        # FIXME
+        # Globbing is broken at the moment:
+        # https://github.com/ansible/ansible-lint-action/issues/30
+        #targets: "**/*.{yaml,yml}"
+        targets: |
+          provisioning/requirements.yml
+          provisioning/playbook.yml
+          provisioning/roles/laprimaire.monitoring/tasks/grafana.yml
+          provisioning/roles/laprimaire.monitoring/tasks/main.yml
+          provisioning/roles/laprimaire.monitoring/tasks/prometheus.yml
+          provisioning/roles/laprimaire.monitoring/defaults/main/grafana.yml
+          provisioning/roles/laprimaire.monitoring/defaults/main/main.yml
+          provisioning/roles/laprimaire.monitoring/defaults/main/prometheus.yml
+          provisioning/roles/laprimaire.monitoring/handlers/main.yml
+          provisioning/roles/laprimaire.reverse-proxy/tasks/main.yml
+          provisioning/roles/laprimaire.reverse-proxy/defaults/main.yml
+          provisioning/roles/laprimaire.reverse-proxy/handlers/main.yml
+          provisioning/roles/laprimaire.logs/tasks/main.yml
+          provisioning/roles/laprimaire.logs/defaults/main.yml
+          provisioning/roles/laprimaire.logs/handlers/main.yml
+          provisioning/roles/laprimaire.analytics/tasks/main.yml
+          provisioning/roles/laprimaire.analytics/defaults/main.yml
+          provisioning/roles/laprimaire.ssl-certs/tasks/main.yml
+          provisioning/roles/laprimaire.blog/files/content/themes/lyra/routes.yaml
+          provisioning/roles/laprimaire.blog/tasks/main.yml
+          provisioning/roles/laprimaire.blog/defaults/main.yml
+          provisioning/roles/laprimaire.blog/handlers/main.yml
+          provisioning/roles/laprimaire.forum/tasks/main.yml
+          provisioning/roles/laprimaire.forum/defaults/main.yml
+          provisioning/hosts.yml
+          provisioning/host_vars/laprimaire_2022/main.yml
+          provisioning/group_vars/all/main.yml
+        # FIXME
+        # Fixing the version of ansible is broken at the moment:
+        # https://github.com/ansible/ansible-lint-action/issues/41
+        #override-deps: |
+        #  ansible==2.9
+        #  ansible-lint==4.3.7
+        args: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+- repo: https://github.com/ansible-community/ansible-lint.git
+  rev: v4.3.7
+  hooks:
+    - id: ansible-lint
+      files: \.(yaml|yml)$

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     - [1.3. Environment variables](#13-environment-variables)
     - [1.4. Provision the development VMs](#14-provision-the-development-vms)
     - [1.5. Adding/removing/upgrading 3rd party Ansible roles](#15-addingremovingupgrading-3rd-party-ansible-roles)
+    - [1.6. Pre-commit hook](#16-pre-commit-hook)
 - [2. Hosts](#2-hosts)
 - [3. Security](#3-security)
     - [3.1. SSL](#31-ssl)
@@ -134,6 +135,12 @@ ansible-galaxy install -r ./provisioning/requirements.yml -p ./provisioning/role
 
 4. Add the new roles (if any) to the git repository with `git add`, commit
 your changes with `git commit` and then push them wight `git push`.
+
+### 1.6. Pre-commit hook
+
+This repository provides a pre-commit hook running `ansible-lint`, to use it:
+- Install [pre-commit](https://pre-commit.com).
+- Run `pre-commit install`.
 
 ## 2. Hosts
 


### PR DESCRIPTION
@JMLX42 This adds a pre-commit hook and a GitHub Action running `ansible-lint`.

If I understand correctly merging can be protected against PR that do not pass linting by enabling the option `Require status checks to pass before merging` and the `ansible-lint` status check in the repository settings -> Branches -> Protect matching branches (the `ansible-lint` status check should appear in the list once this PR is merged).

I had to add two new ignored errors in the `.ansible-lint` `skip_list`:
- '106' # Ignore error [106] Role name does not match ^[a-z][a-z0-9_]+$ pattern.
- '208' # Ignore error [208] File permissions unset or incorrect.

Note that:
- The pre-commit uses a regex and will lint all the .yml and .yaml files.
- However globbing is currently broken in the `ansible-lint-action`:
    - https://github.com/ansible/ansible-lint-action/issues/30
    - So I temporarily had to list all the yaml files.
    - I will have to create an issue and fix this when the `ansible-lint-action` is fixed.
- Also I could not explicitly set the version of `ansible` and `ansible-lint` used due to another bug:
    - https://github.com/ansible/ansible-lint-action/issues/41
    - I will have to create an issue and fix this when the `ansible-lint-action` is fixed.